### PR TITLE
[config_maker] Ensure to make sub folders in `stageDir` for new apps.

### DIFF
--- a/config_maker/lib.ts
+++ b/config_maker/lib.ts
@@ -156,20 +156,15 @@ export class ConfigMaker {
     // Handle new configuration files
     const message = isInit ? "Initial import." : `Add empty placeholders on ${(new Date()).toLocaleString()}.`
     await Promise.all(this.specs.map(spec =>
-      Promise.all(spec.files.map(file => {
+      Promise.all(spec.files.map(async file => {
           const instDir = this.match(file, spec.context.install)
-          if(instDir) {
-            const target_file = path.join(instDir, file)
-            const link_dir = path.join(this.stageDir, spec.app)
-            return (async () => {
-              await fs.ensureFile(target_file)
-              await fs.ensureDir(link_dir)
-              await fs.ensureLink(target_file, path.join(link_dir, file))
-            })()
-          }
-        }
-      )))
-    )
+          if (!instDir) return
+          const targetFile = path.join(instDir, file)
+          const destPath = path.join(this.stageDir, spec.app, file)
+          await fs.ensureFile(targetFile)
+          await fs.ensureLink(targetFile, destPath)
+      }))
+    ))
     await exec('git add .', {'cwd': this.stageDir})
     await exec(`git diff-index --quiet HEAD || git commit -m "${message}."`, {'cwd': this.stageDir})
   }

--- a/config_maker/lib.ts
+++ b/config_maker/lib.ts
@@ -157,14 +157,19 @@ export class ConfigMaker {
     const message = isInit ? "Initial import." : `Add empty placeholders on ${(new Date()).toLocaleString()}.`
     await Promise.all(this.specs.map(spec =>
       Promise.all(spec.files.map(file => {
-        const instDir = this.match(file, spec.context.install)
-        if(instDir) {
-          return fs.ensureFile(path.join(instDir, file)).then(
-            () => fs.ensureLink(path.join(instDir, file), path.join(this.stageDir, spec.app, file))
-          )
+          const instDir = this.match(file, spec.context.install)
+          if(instDir) {
+            const target_file = path.join(instDir, file)
+            const link_dir = path.join(this.stageDir, spec.app)
+            return (async () => {
+              await fs.ensureFile(target_file)
+              await fs.ensureDir(link_dir)
+              await fs.ensureLink(target_file, path.join(link_dir, file))
+            })()
+          }
         }
-      }))
-    ))
+      )))
+    )
     await exec('git add .', {'cwd': this.stageDir})
     await exec(`git diff-index --quiet HEAD || git commit -m "${message}."`, {'cwd': this.stageDir})
   }


### PR DESCRIPTION
Closes GH-92.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust configuration staging when templates specify installation contexts: the process now ensures target files exist, creates per-application staging paths, and reliably establishes symbolic links into the correct staging locations, improving stability and correctness of file staging during configuration setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yak1ex/configurator/pull/100)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->