### PR TITLE
[config_maker] Extract feature flags as an object in context (closes GH-102).

### DIFF
--- a/config_maker/lib.ts
+++ b/config_maker/lib.ts
@@ -39,6 +39,10 @@ interface Spec {
   files: string[]
 }
 
+interface Feature {
+  office: boolean
+}
+
 export class ConfigMaker {
   private currDir: string
   private prevDir: string
@@ -74,12 +78,14 @@ export class ConfigMaker {
       set: function(obj, prop, value) { return false; }
     })
 
-    let is_office: boolean = process.env['USERDOMAIN'] === 'DNJP'
+    let feature : Feature = {
+      office: process.env['USERDOMAIN'] === 'DNJP'
+    }
 
     // FIXME: pf32, pf64
 
     let context_base = {
-      make_counter, env, is_office, pf32: 'c:\\Program Files'
+      make_counter, env, feature, pf32: 'c:\\Program Files'
     };
     return context_base
   }

--- a/config_maker/lib.ts
+++ b/config_maker/lib.ts
@@ -78,9 +78,9 @@ export class ConfigMaker {
       set: function(obj, prop, value) { return false; }
     })
 
-    let feature : Feature = {
+    let feature : Feature = Object.freeze<Feature>({
       office: process.env['USERDOMAIN'] === 'DNJP'
-    }
+    })
 
     // FIXME: pf32, pf64
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Template context reorganized: the office flag is now nested inside a feature object. Update templates to read the nested flag rather than the previous top-level flag. This changes how template conditions reference the office setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yak1ex/configurator/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->